### PR TITLE
Fixing issue #66. `C2SStream` now properly supports asynchronous callbac...

### DIFF
--- a/lib/c2s/stream.js
+++ b/lib/c2s/stream.js
@@ -257,6 +257,7 @@ C2SStream.prototype.onRegistration = function(stanza) {
             .c('instructions').t(instructions).up()
             .c('username').up()
             .c('password')
+        proceed()
     } else if (stanza.attrs.type === 'set') {
         var jid = new JID(register.getChildText('username'),
                           this.server.options.domain)
@@ -285,9 +286,13 @@ C2SStream.prototype.onRegistration = function(stanza) {
                         })
                         .t(error.message)
                 }
+                proceed()
             })
     }
-    self.send(reply)
+
+    function proceed() {
+        self.send(reply)
+    }
 }
 
 C2SStream.prototype.onBind = function(stanza) {


### PR DESCRIPTION
Fixing issue #66. `C2SStream` now properly supports asynchronous callbacks when dealing with registration failures.

Issue: https://github.com/node-xmpp/node-xmpp-server/issues/66

Edit (@lloydwatkin): Closes #66 