### PR TITLE
Fixed not closing the socket on response close event

### DIFF
--- a/lib/bosh/http.js
+++ b/lib/bosh/http.js
@@ -122,6 +122,10 @@ BOSHServer.prototype._useExistingSession = function(req, res, bodyEl) {
         )
         res.end('BOSH session not found')
     }
+
+    res.on('close', function () {
+        session.closeSocket()
+    })
 }
 
 BOSHServer.prototype._createSession = function(req, res, bodyEl) {


### PR DESCRIPTION
When a client unexpectedly closes the http connection it emits a 'close' event to the `response` object (http://nodejs.org/api/http.html#http_event_close_1). We need to capture that and make sure that we send the 'end' event to the session socket (session.closeSocket() takes care of that).