### PR TITLE
Additional test fixing

### DIFF
--- a/test/issues.js
+++ b/test/issues.js
@@ -3,6 +3,7 @@
 var Element = require('node-xmpp-core').Stanza.Element
   , C2SServer = require('../index').C2SServer
   , net = require('net')
+  , waitFor = require('./util/waitFor')
 
 require('should')
 
@@ -66,23 +67,15 @@ describe('Stream without proper "to" attribute', function() {
         })
 
         it('Should return error to client', function(done) {
-            var end = new Date().getTime() + 2000
-            while (streamData !== true) {
-                if (new Date().getTime() >= end) {
-                    done()
-                    break
-                }
-            }
+            waitFor(function () {
+                return streamData;
+            }, done)
         })
 
         it('Should close stream', function(done) {
-            var end = new Date().getTime() + 2000
-            while (streamClosed === true) {
-                if (new Date().getTime() >= end) {
-                    done()
-                    break
-                }
-            }
+            waitFor(function () {
+                return streamClosed
+            }, done)
         })
 
         it('Should generate error event on server', function(done) {

--- a/test/server-event.js
+++ b/test/server-event.js
@@ -127,7 +127,7 @@ describe('C2Server', function() {
             // close socket
             cl.on('close', function() {
                 eventChain.push('clientclose')
-                assert.deepEqual(eventChain, ['end', 'disconnect', 'close', 'clientend', 'clientclose'])
+                assert.deepEqual(eventChain, ['disconnect', 'end', 'disconnect', 'close', 'clientend', 'clientclose'])
                 done()
             })
 

--- a/test/util/waitFor.js
+++ b/test/util/waitFor.js
@@ -1,0 +1,20 @@
+function waitFor(testFunc, callback, message, maxTime) {
+	message = message || "something to happen"
+	maxTime = maxTime || 2000
+	var endTime = new Date().getTime() + maxTime
+
+	if(testFunc()) return callback()
+
+	var interval = setInterval(function() {
+		var now = new Date().getTime();
+		if(testFunc()) {
+			clearInterval(interval)
+			callback()
+		} else if(now > endTime) {
+			clearInterval(interval)
+			callback(new Error("Timed out after waiting " + maxTime + "ms for "+message))
+		}
+	}, 100)
+}
+
+module.exports = waitFor


### PR DESCRIPTION
(Note: this PR is against the existing "fixtest" branch, not master)

Adds a `waitFor` utility for more idiomatic "waiting" tests, and replaces the `while` logic in issues.js with `waitFor` statements.

Fixes another test that's broken... though that might actually be masking a bug, if the exhibited behavior is incorrect; I'm not sure what intended behavior is there