### PR TITLE
Fix crash with * CORS origin and missing origin header

### DIFF
--- a/lib/bosh/http.js
+++ b/lib/bosh/http.js
@@ -62,7 +62,7 @@ BOSHServer.prototype.setCorsHeader = function(req, res, options) {
     var origin = options.origin
     if (Array.isArray(options.origin)) {
         origin = options.origin.indexOf(req.headers.origin) > -1 ? req.headers.origin : undefined
-    } else if (options.origin === '*') {
+    } else if ((options.origin === '*') && req.headers.origin) {
         origin = req.headers.origin
     }
 


### PR DESCRIPTION
If you had set options.origin to ```*``` and the request didn't have origin header, the server would crash trying to set a header with a ```undefined``` value.