### PR TITLE
Fix crash with array CORS origin and invalid origin header

### DIFF
--- a/lib/bosh/http.js
+++ b/lib/bosh/http.js
@@ -62,11 +62,13 @@ BOSHServer.prototype.setCorsHeader = function(req, res, options) {
     var origin = options.origin
     if (Array.isArray(options.origin)) {
         origin = options.origin.indexOf(req.headers.origin) > -1 ? req.headers.origin : undefined
-    } else if ((options.origin === '*') && req.headers.origin) {
+    } else if (options.origin === '*') {
         origin = req.headers.origin
     }
 
-    res.setHeader('Access-Control-Allow-Origin', origin)
+    if (origin) {
+        res.setHeader('Access-Control-Allow-Origin', origin)
+    }
     res.setHeader('Access-Control-Allow-Credentials', options.credentials)
     res.setHeader('Access-Control-Allow-Methods', options.methods.join(', '))
     res.setHeader('Access-Control-Allow-Headers', options.headers.join(', '))


### PR DESCRIPTION
Would crash if the origin option was an array and req.headers.origin didn't match any.

BTW Didn't find out sooner about this and https://github.com/node-xmpp/node-xmpp-server/pull/91 because setting undefined as a header value only raises an exception in Node.js 0.12 and we just made the switch.