### PR TITLE
* Fixing all namespaces <features> declaration.

### DIFF
--- a/lib/c2s/stream.js
+++ b/lib/c2s/stream.js
@@ -13,6 +13,7 @@ var NS_REGISTER = 'jabber:iq:register'
 var NS_SESSION = 'urn:ietf:params:xml:ns:xmpp-session'
 var NS_BIND = 'urn:ietf:params:xml:ns:xmpp-bind'
 var NS_STANZAS = 'urn:ietf:params:xml:ns:xmpp-stanzas'
+var NS_STREAM = 'http://etherx.jabber.org/streams'
 
 function C2SStream(opts) {
     var self = this
@@ -103,7 +104,7 @@ C2SStream.prototype.decode64 = function (encoded) {
 }
 
 C2SStream.prototype.sendFeatures = function () {
-    var features = new Element('stream:features')
+    var features = new Element('features', {'xmlns': NS_STREAM})
     if (!this.authenticated) {
         if (this.server && this.server.availableSaslMechanisms) {
             // TLS

--- a/lib/websocket/server.js
+++ b/lib/websocket/server.js
@@ -6,6 +6,9 @@ var util = require('util')
   , CS2Server = require('../c2s/server')
   , C2SStream = require('../c2s/stream')
   , debug = require('debug')('xmpp:server:websocket')
+  , https = require('https')
+  , fs = require('fs')
+
 
 function WsServer(options) {
   this.wsoptions = options || {}
@@ -28,9 +31,23 @@ WsServer.prototype.C2SStream = C2SStream
 WsServer.prototype.listen = function() {
   var self = this
 
-  this.wss = new WebSocketServer({
-    port: self.wsoptions.port
-  })
+  if(self.options.tls){
+      var tlsoptions = {
+          key: fs.readFileSync(self.options.tls.keyPath),
+          cert: fs.readFileSync(self.options.tls.certPath)
+      };
+
+      var server = https.createServer(tlsoptions);
+
+      this.wss = new WebSocketServer({
+          server: server
+      })
+      server.listen(self.wsoptions.port);
+  }else {
+      this.wss = new WebSocketServer({
+          port: self.wsoptions.port
+      })
+  }
 
   this.wss.once('listening', function() {
     self.emit('online')

--- a/lib/websocket/server.js
+++ b/lib/websocket/server.js
@@ -31,10 +31,10 @@ WsServer.prototype.C2SStream = C2SStream
 WsServer.prototype.listen = function() {
   var self = this
 
-  if(self.options.tls){
+  if(self.wsoptions.tls){
       var tlsoptions = {
-          key: fs.readFileSync(self.options.tls.keyPath),
-          cert: fs.readFileSync(self.options.tls.certPath)
+          key: fs.readFileSync(self.wsoptions.tls.keyPath),
+          cert: fs.readFileSync(self.wsoptions.tls.certPath)
       };
 
       var server = https.createServer(tlsoptions);

--- a/lib/websocket/server.js
+++ b/lib/websocket/server.js
@@ -42,7 +42,7 @@ WsServer.prototype.listen = function() {
       this.wss = new WebSocketServer({
           server: server
       })
-      server.listen(self.wsoptions.port);
+      server.listen(self.wsoptions.port, self.wsoptions.bindAddress);
   }else {
       this.wss = new WebSocketServer({
           port: self.wsoptions.port

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "hat": "~0.0.3",
     "node-xmpp-core": "^1.0.0-alpha14",
     "debug": "~2.1.2",
-    "ws": "~0.7.1"
+    "ws": "~0.7.2"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
As stated in http://xmpp.org/rfcs/rfc6120.html#streams-ns-content , all definitions of namespaces or prefixes must be coherent, and thus we cant mix `<stream:features>` with `<mechanisms xmlns="...">`.
So with this change both are namespace-based and we send `<features xmlns="...">` instead.