### PR TITLE
Fixed bug unregisterSaslMechanism

### DIFF
--- a/lib/c2s/server.js
+++ b/lib/c2s/server.js
@@ -133,7 +133,7 @@ C2SServer.prototype.unregisterSaslMechanism = function(method) {
     // check if method is registered
     var index = this.availableSaslMechanisms.indexOf(method)
     if (index >= 0) {
-        this.availableSaslMechanisms = this.availableSaslMechanisms.splice(index, 1)
+        this.availableSaslMechanisms.splice(index, 1)
     }
 }
 


### PR DESCRIPTION
splice returns an array of removed elements while modifying the array in-place. There is no need to re-assign this.availableSaslMechanisms and in this case doing so will have the exact opposite of the desired effect.