### PR TITLE
Add TLS/HTTPS support with websockets

### DIFF
--- a/lib/websocket/server.js
+++ b/lib/websocket/server.js
@@ -6,6 +6,9 @@ var util = require('util')
   , CS2Server = require('../c2s/server')
   , C2SStream = require('../c2s/stream')
   , debug = require('debug')('xmpp:server:websocket')
+  , https = require('https')
+  , fs = require('fs')
+
 
 function WsServer(options) {
   this.wsoptions = options || {}
@@ -28,9 +31,23 @@ WsServer.prototype.C2SStream = C2SStream
 WsServer.prototype.listen = function() {
   var self = this
 
-  this.wss = new WebSocketServer({
-    port: self.wsoptions.port
-  })
+  if(self.options.tls){
+      var tlsoptions = {
+          key: fs.readFileSync(self.options.tls.keyPath),
+          cert: fs.readFileSync(self.options.tls.certPath)
+      };
+
+      var server = https.createServer(tlsoptions);
+
+      this.wss = new WebSocketServer({
+          server: server
+      })
+      server.listen(self.wsoptions.port);
+  }else {
+      this.wss = new WebSocketServer({
+          port: self.wsoptions.port
+      })
+  }
 
   this.wss.once('listening', function() {
     self.emit('online')

--- a/lib/websocket/server.js
+++ b/lib/websocket/server.js
@@ -31,10 +31,10 @@ WsServer.prototype.C2SStream = C2SStream
 WsServer.prototype.listen = function() {
   var self = this
 
-  if(self.options.tls){
+  if(self.wsoptions.tls){
       var tlsoptions = {
-          key: fs.readFileSync(self.options.tls.keyPath),
-          cert: fs.readFileSync(self.options.tls.certPath)
+          key: fs.readFileSync(self.wsoptions.tls.keyPath),
+          cert: fs.readFileSync(self.wsoptions.tls.certPath)
       };
 
       var server = https.createServer(tlsoptions);

--- a/lib/websocket/server.js
+++ b/lib/websocket/server.js
@@ -42,7 +42,7 @@ WsServer.prototype.listen = function() {
       this.wss = new WebSocketServer({
           server: server
       })
-      server.listen(self.wsoptions.port);
+      server.listen(self.wsoptions.port, self.wsoptions.bindAddress);
   }else {
       this.wss = new WebSocketServer({
           port: self.wsoptions.port


### PR DESCRIPTION
TLS/HTTPS support for WebSockets implementation using the syntax used for TCP sockets in Server options.
*Extracted from last three commits.*