### PR TITLE
Improve error handling on component sessions.

### DIFF
--- a/lib/component/Session.js
+++ b/lib/component/Session.js
@@ -24,12 +24,16 @@ ComponentSession.prototype.NS_COMPONENT = 'jabber:component:accept'
 ComponentSession.prototype.NS_STREAM = 'http://etherx.jabber.org/streams'
 
 ComponentSession.prototype.onStreamStart = function (streamAttrs) {
+  if (streamAttrs.xmlns !== this.NS_COMPONENT) {
+    this.connection.error('invalid-namespace', "invalid namespace '" + streamAttrs.xmlns + "'")
+    return
+  }
+  
   var self = this
   this.jid = new JID(streamAttrs.to)
   this.emit('verify-component', this.jid, function (err, password) {
     if (err) {
-      self.connection.send(new Element('host-unknown'))
-      self.connection.end()
+      self.connection.error('host-unknown', err.message)
     } else {
       if (!streamAttrs.id) streamAttrs.id = Date.now()
       self.expectedDigest = self._sha1Hex((streamAttrs.id || '') + password)

--- a/lib/component/Session.js
+++ b/lib/component/Session.js
@@ -28,7 +28,7 @@ ComponentSession.prototype.onStreamStart = function (streamAttrs) {
     this.connection.error('invalid-namespace', "invalid namespace '" + streamAttrs.xmlns + "'")
     return
   }
-  
+
   var self = this
   this.jid = new JID(streamAttrs.to)
   this.emit('verify-component', this.jid, function (err, password) {

--- a/lib/component/Session.js
+++ b/lib/component/Session.js
@@ -33,7 +33,7 @@ ComponentSession.prototype.onStreamStart = function (streamAttrs) {
   this.jid = new JID(streamAttrs.to)
   this.emit('verify-component', this.jid, function (err, password) {
     if (err) {
-      self.connection.error('host-unknown', err.message)
+      self.connection.error('host-unknown', err.message || 'unknown host')
     } else {
       if (!streamAttrs.id) streamAttrs.id = Date.now()
       self.expectedDigest = self._sha1Hex((streamAttrs.id || '') + password)

--- a/lib/component/Session.js
+++ b/lib/component/Session.js
@@ -55,8 +55,7 @@ ComponentSession.prototype.onStanza = function (stanza) {
     this.emit('online')
     this.authenticated = true
   } else {
-    // Per XEP-0114 DO NOT return any errors, just close the connection
-    this.end()
+    this.connection.error('not-authorized', 'not authorized')
   }
 }
 

--- a/test/integration/component.js
+++ b/test/integration/component.js
@@ -1,7 +1,8 @@
 'use strict'
 
-/* global describe, it */
+/* global describe, before, after, it */
 
+var assert = require('assert')
 var XMPP = require('../..')
 var Server = XMPP.component.Server
 var Component = require('node-xmpp-component')
@@ -11,7 +12,12 @@ var server = new Server({
 })
 server.on('connection', function (connection) {
   connection.on('verify-component', function (jid, cb) {
-    cb(null, 'password')
+    switch (jid.toString()) {
+      case 'foo.localhost':
+        return cb(null, 'password')
+      default:
+        return cb(new Error('unknown host'))
+    }
   })
 
   connection.on('stanza', function (stanza) {
@@ -19,6 +25,7 @@ server.on('connection', function (connection) {
     stanza.attrs.to = connection.jid
     connection.send(stanza)
   })
+  connection.on('error', function () {})
 })
 
 describe('component server - component', function () {
@@ -38,6 +45,48 @@ describe('component server - component', function () {
       })
       component.on('error', done)
       component.on('online', done)
+    })
+  })
+
+  describe('component not serviced by server', function () {
+    it('should connect', function (done) {
+      var component = new Component({
+        jid: 'unknown.localhost',
+        password: 'password',
+        host: 'localhost',
+        port: 5347
+      })
+      component.on('error', done)
+      component.on('disconnect', function (err) {
+        assert.equal(err.message, 'unknown host')
+        done()
+      })
+    })
+  })
+
+  describe('component that uses wrong namespace', function () {
+    var NS_COMPONENT = Component.prototype.NS_COMPONENT
+
+    before(function () {
+      Component.prototype.NS_COMPONENT = 'jabber:component:wrong'
+    })
+
+    after(function () {
+      Component.prototype.NS_COMPONENT = NS_COMPONENT
+    })
+
+    it('should error if wrong namespace', function (done) {
+      var component = new Component({
+        jid: 'foo.localhost',
+        password: 'password',
+        host: 'localhost',
+        port: 5347
+      })
+      component.on('error', done)
+      component.on('disconnect', function (err) {
+        assert.equal(err.message, "invalid namespace 'jabber:component:wrong'")
+        done()
+      })
     })
   })
 })

--- a/test/integration/component.js
+++ b/test/integration/component.js
@@ -59,6 +59,24 @@ describe('component server - component', function () {
       component.on('error', done)
       component.on('disconnect', function (err) {
         assert.equal(err.message, 'unknown host')
+        assert.equal(err.stanza.children[0].name, 'host-unknown')
+        done()
+      })
+    })
+  })
+
+  describe('component supplied invalid credentials', function () {
+    it('should connect', function (done) {
+      var component = new Component({
+        jid: 'foo.localhost',
+        password: 'notthepassword',
+        host: 'localhost',
+        port: 5347
+      })
+      component.on('error', done)
+      component.on('disconnect', function (err) {
+        assert.equal(err.message, 'not authorized')
+        assert.equal(err.stanza.children[0].name, 'not-authorized')
         done()
       })
     })
@@ -85,6 +103,7 @@ describe('component server - component', function () {
       component.on('error', done)
       component.on('disconnect', function (err) {
         assert.equal(err.message, "invalid namespace 'jabber:component:wrong'")
+        assert.equal(err.stanza.children[0].name, 'invalid-namespace')
         done()
       })
     })


### PR DESCRIPTION
This patch improves error handling on component connections.  In particular, it does two things:

1. If the content namespace is incorrect, it closes the stream with a `invalid-namespace` error.
2. If authentication fails, it closes the error with a stream error, rather than an unqualified element.

Both modifications are in accordance with http://xmpp.org/extensions/xep-0114.html